### PR TITLE
Add option to enable/disable logging.

### DIFF
--- a/app/code/community/Aoe/AsyncCache/Model/Cleaner.php
+++ b/app/code/community/Aoe/AsyncCache/Model/Cleaner.php
@@ -25,7 +25,9 @@ class Aoe_AsyncCache_Model_Cleaner extends Mage_Core_Model_Abstract {
 				$startTime = time();
 				Mage::app()->getCache()->clean($job['mode'], $job['tags'], true);
 				$job['duration'] = time() - $startTime;
-				Mage::log('[ASYNCCACHE] MODE: ' . $job['mode'] . ', DURATION: ' . $job['duration'] . ' sec, TAGS: ' . implode(', ', $job['tags']));
+                if (Mage::getStoreConfigFlag('dev/log/aoeAsyncCacheActive')) {
+				    Mage::log('[ASYNCCACHE] MODE: ' . $job['mode'] . ', DURATION: ' . $job['duration'] . ' sec, TAGS: ' . implode(', ', $job['tags']));
+                }
 			}
 
 			// delete all affected asynccache database rows

--- a/app/code/community/Aoe/AsyncCache/etc/config.xml
+++ b/app/code/community/Aoe/AsyncCache/etc/config.xml
@@ -107,6 +107,11 @@
 				<scheduler_cron_expr>*/15 * * * *</scheduler_cron_expr>
 			</aoeasynccache>
 		</system>
+		<dev>
+			<log>
+				<aoeAsyncCacheActive>1</aoeAsyncCacheActive>
+			</log>
+		</dev>
 	</default>
 
 </config>

--- a/app/code/community/Aoe/AsyncCache/etc/system.xml
+++ b/app/code/community/Aoe/AsyncCache/etc/system.xml
@@ -34,5 +34,22 @@
 				</aoeasynccache>
 			</groups>
 		</system>
+		<dev>
+			<groups>
+				<log>
+					<fields>
+						<aoeAsyncCacheActive translate="label">
+							<label>Log Aoe_AsyncCache messages</label>
+							<frontend_type>select</frontend_type>
+							<source_model>adminhtml/system_config_source_yesno</source_model>
+							<sort_order>80</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</aoeAsyncCacheActive>
+					</fields>
+				</log>
+			</groups>
+		</dev>
 	</sections>
 </config>


### PR DESCRIPTION
Aoe_AsyncCache logs every job (mode, duration, tags) in system.log. This feature adds lines to our log which we don't need.

Therefore I added the option to disable logging for this information. Errors are still logged. By default logging stays enabled so the default behaviour is unchanged.

I didn't bump up the version number in case you want to handle this yourself.
